### PR TITLE
Add organization readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,16 @@
+# Eclipse Thingweb
+
+Eclipse Thingweb™ offers components for making IoT solutions interoperable at scale by leveraging the W3C WoT standards, no matter if improving an existing solution or building a new one:
+
+- Describe devices: information, capabilities, and data schemas in a standardized format
+- Integrate devices: connectivity via various IoT protocols under a uniform interface
+- Validate device descriptions: consistent metadata for your devices and across directories
+- Develop applications: Web browser-like runtime for (headless) portable IoT apps
+
+Each component within the Eclipse Thingweb™ project is designed to be used independently from each other while working harmoniously together. This gives developers the flexibility to choose the specific tools they need for their IoT solution without sacrificing interoperability.
+
+Selected libraries, tools, and services: (more on GitHub):
+
+- [node-wot](https://github.com/eclipse-thingweb/node-wot): Components for building IoT devices or for interacting with them over various IoT protocols 
+- [playground](https://github.com/eclipse-thingweb/playground): Thing Description (TD) and Thing Model (TM) validation and manipulation
+- [Online Things](http://plugfest.thingweb.io/): Simulated IoT devices to test different IoT protocols


### PR DESCRIPTION
First version of the landing after the new one in the Eclipse page.

A subsequent one can add a logo or more information. Ideally aligned with thingweb.io